### PR TITLE
Changes

### DIFF
--- a/src/winsvc.ml
+++ b/src/winsvc.ml
@@ -1,14 +1,14 @@
 external install : string -> string -> string -> string -> unit
-  = "caml_winsvc_install"
+  = "winsvc_install"
 
-external remove : string -> unit = "caml_winsvc_remove"
+external remove : string -> unit = "winsvc_remove"
 
 external run : string -> (unit -> unit) -> (unit -> unit) -> unit
-  = "caml_winsvc_run"
+  = "winsvc_run"
 
 exception Error of string
 
-let () = Callback.register_exception "caml_winsvc_exn" (Error "register");
+let () = Callback.register_exception "winsvc_exn" (Error "register");
 
 module type Sig = sig
   val name : string

--- a/src/winsvc.mli
+++ b/src/winsvc.mli
@@ -32,6 +32,8 @@ module Make (S : Sig) : sig
 
   (** [run main]
     @param main function to run, stdin/stdout not available (will raise exception if used),
-                when [S.stop] is called this function should return as soon as possible *)
+                when [S.stop] is called this function should return as soon as possible.
+    @raise Failure if the program is being run as a console application rather than as a
+                   service. *)
   val run : (unit -> unit) -> unit
 end

--- a/src/winsvc_stubs.c
+++ b/src/winsvc_stubs.c
@@ -99,9 +99,9 @@ void service_main(DWORD argc, WCHAR **argv) {
   report_status(SERVICE_STOPPED, NO_ERROR, 2000);
 }
 
-#define raise_error(str) caml_raise_with_string(*caml_named_value("caml_service_exn"), str)
+#define raise_error(str) caml_raise_with_string(*caml_named_value("winsvc_exn"), str)
 
-CAMLprim value caml_winsvc_install(value v_name, value v_display, value v_text,
+CAMLprim value winsvc_install(value v_name, value v_display, value v_text,
                                     value v_path) {
   CAMLparam4(v_name, v_display, v_text, v_path);
 
@@ -145,7 +145,7 @@ CAMLprim value caml_winsvc_install(value v_name, value v_display, value v_text,
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_winsvc_remove(value v_name) {
+CAMLprim value winsvc_remove(value v_name) {
   CAMLparam1(v_name);
 
   SC_HANDLE handle_manager;
@@ -190,7 +190,7 @@ CAMLprim value caml_winsvc_remove(value v_name) {
   CAMLreturn(Val_unit);
 }
 
-CAMLprim value caml_winsvc_run(value v_name, value v_run, value v_stop) {
+CAMLprim value winsvc_run(value v_name, value v_run, value v_stop) {
   CAMLparam3(v_name, v_run, v_stop);
   BOOL result;
   char_os *s_name = caml_stat_strdup_to_os(String_val(v_name));

--- a/src/winsvc_stubs.c
+++ b/src/winsvc_stubs.c
@@ -111,7 +111,7 @@ CAMLprim value winsvc_install(value v_name, value v_display, value v_text,
   char_os *name, *display, *text, *path;
 
   handle_manager = OpenSCManager(0, 0, SC_MANAGER_ALL_ACCESS);
-  if (handle_manager == 0) {
+  if (handle_manager == NULL) {
     raise_error("Failed to open service control manager");
   }
 
@@ -128,7 +128,7 @@ CAMLprim value winsvc_install(value v_name, value v_display, value v_text,
   caml_stat_free(display);
   caml_stat_free(path);
 
-  if (handle_service == 0) {
+  if (handle_service == NULL) {
     CloseServiceHandle(handle_manager);
     raise_error("Failed to create service in service control manager");
   }
@@ -155,7 +155,7 @@ CAMLprim value winsvc_remove(value v_name) {
   char_os *name;
 
   handle_manager = OpenSCManager(0, 0, SC_MANAGER_ALL_ACCESS);
-  if (handle_manager == 0) {
+  if (handle_manager == NULL) {
     raise_error("Failed to open service control manager");
   }
 
@@ -163,7 +163,7 @@ CAMLprim value winsvc_remove(value v_name) {
   handle_service =
       OpenService(handle_manager, name, SERVICE_ALL_ACCESS);
   caml_stat_free(name);
-  if (handle_service == 0) {
+  if (handle_service == NULL) {
     CloseServiceHandle(handle_manager);
     raise_error("Failed to open service in service control manager");
   }
@@ -183,7 +183,7 @@ CAMLprim value winsvc_remove(value v_name) {
   CloseServiceHandle(handle_service);
   CloseServiceHandle(handle_manager);
 
-  if (0 == result) {
+  if (!result) {
     raise_error("Failed to remove service");
   }
 
@@ -221,7 +221,7 @@ CAMLprim value winsvc_run(value v_name, value v_run, value v_stop) {
   s_service_name = NULL;
   caml_stat_free(s_name);
 
-  if (FALSE == result)
+  if (!result)
     raise_error("Failed to run service");
 
   CAMLreturn(Val_unit);

--- a/src/winsvc_stubs.c
+++ b/src/winsvc_stubs.c
@@ -250,8 +250,12 @@ CAMLprim value winsvc_run(value v_name, value v_run, value v_stop) {
   s_service_name = NULL;
   caml_stat_free(s_name);
 
-  if (!result)
-    raise_error(L"StartServiceCtrlDispatcher", rc);
+  if (!result) {
+    if (rc == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT)
+      caml_failwith("ERROR_FAILED_SERVICE_CONTROLLER_CONNECT");
+    else
+      raise_error(L"StartServiceCtrlDispatcher", rc);
+  }
 
   CAMLreturn(Val_unit);
 }

--- a/src/winsvc_stubs.c
+++ b/src/winsvc_stubs.c
@@ -31,7 +31,7 @@ static value cb_service_run = Val_unit;
 static value cb_service_stop = Val_unit;
 static char_os *s_service_name = NULL;
 
-void call_service_run(void) {
+static void call_service_run(void) {
   assert(Val_unit != cb_service_run);
   caml_c_thread_register();
   caml_acquire_runtime_system();
@@ -40,7 +40,7 @@ void call_service_run(void) {
   caml_c_thread_unregister();
 }
 
-void call_service_stop(void) {
+static void call_service_stop(void) {
   assert(Val_unit != cb_service_stop);
 
   caml_c_thread_register();
@@ -50,11 +50,11 @@ void call_service_stop(void) {
   caml_c_thread_unregister();
 }
 
-static SERVICE_STATUS service_status;	
-static SERVICE_STATUS_HANDLE handle_service_status = 0;	
+static SERVICE_STATUS service_status;
+static SERVICE_STATUS_HANDLE handle_service_status = 0;
 static int check_point = 1;
 
-BOOL report_status(DWORD current_state, DWORD win32_exitcode, DWORD wait_hint) {
+static BOOL report_status(DWORD current_state, DWORD win32_exitcode, DWORD wait_hint) {
   if (current_state != SERVICE_START_PENDING)
     service_status.dwControlsAccepted = SERVICE_ACCEPT_STOP;
   service_status.dwCurrentState = current_state;
@@ -70,13 +70,13 @@ BOOL report_status(DWORD current_state, DWORD win32_exitcode, DWORD wait_hint) {
   return SetServiceStatus(handle_service_status, &service_status);
 }
 
-void stop_service() {
+static void stop_service() {
   report_status(SERVICE_STOP_PENDING, NO_ERROR, 1000);
 
   call_service_stop();
 }
 
-void WINAPI service_ctrl_handler(DWORD ctrl_code) {
+static void WINAPI service_ctrl_handler(DWORD ctrl_code) {
   if (ctrl_code == SERVICE_CONTROL_STOP) {
     stop_service();
   } else {
@@ -84,7 +84,7 @@ void WINAPI service_ctrl_handler(DWORD ctrl_code) {
   }
 }
 
-void service_main(DWORD argc, WCHAR **argv) {
+static void service_main(DWORD argc, WCHAR **argv) {
   memset(&service_status, 0, sizeof(SERVICE_STATUS));
   service_status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
   service_status.dwServiceSpecificExitCode = 0;


### PR DESCRIPTION
Hi!
This PR introduces fixes and some changes:
- switches completely to the Windows Unicode API and handles conversion from OCaml strings to OS strings;
- doesn't use the `caml_winsvc_` prefix but only `winsvc_` as `caml_` is reserved by OCaml standard library;
- improves the error reporting by using system error messages;
- introduces a new exception to handle the case where a program isn't launched through the Windows Service manager;
- and adds small C improvements.
Let me know what you think!