### PR TITLE
Lower-bound OCaml dependency to 4.06

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,4 +11,5 @@
 (package
  (name winsvc)
  (synopsis "Library to make OCaml program act as a Windows service")
- (depends dune))
+ (depends
+  (ocaml (>= 4.06))))

--- a/winsvc.opam
+++ b/winsvc.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/savonet/ocaml-winsvc"
 bug-reports: "https://github.com/savonet/ocaml-winsvc/issues"
 depends: [
   "dune" {>= "2.8"}
+  "ocaml" {>= "4.06"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This was requested by the maintainers of opam-repository. I also include it here for the future.

Also remove Dune dependency from `dune-project` as it's implicit.